### PR TITLE
Add API definitions for 0.9.0.1

### DIFF
--- a/docs/code/modules/protocol.consumer_metadata.rst
+++ b/docs/code/modules/protocol.consumer_metadata.rst
@@ -1,5 +1,0 @@
-``kiel.protocol.consumer_metadata``
-===================================
-
-.. automodule:: kiel.protocol.consumer_metadata
-    :members:

--- a/docs/code/modules/protocol.coordinator.rst
+++ b/docs/code/modules/protocol.coordinator.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.coordinator``
+=============================
+
+.. automodule:: kiel.protocol.coordinator
+    :members:

--- a/docs/code/modules/protocol.describe_groups.rst
+++ b/docs/code/modules/protocol.describe_groups.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.describe_groups``
+=================================
+
+.. automodule:: kiel.protocol.describe_groups
+    :members:

--- a/docs/code/modules/protocol.heartbeat.rst
+++ b/docs/code/modules/protocol.heartbeat.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.heartbeat``
+===========================
+
+.. automodule:: kiel.protocol.heartbeat
+    :members:

--- a/docs/code/modules/protocol.join_group.rst
+++ b/docs/code/modules/protocol.join_group.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.join_group``
+============================
+
+.. automodule:: kiel.protocol.join_group
+    :members:

--- a/docs/code/modules/protocol.leave_group.rst
+++ b/docs/code/modules/protocol.leave_group.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.leave_group``
+=============================
+
+.. automodule:: kiel.protocol.leave_group
+    :members:

--- a/docs/code/modules/protocol.list_groups.rst
+++ b/docs/code/modules/protocol.list_groups.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.list_groups``
+=============================
+
+.. automodule:: kiel.protocol.list_groups
+    :members:

--- a/docs/code/modules/protocol.sync_group.rst
+++ b/docs/code/modules/protocol.sync_group.rst
@@ -1,0 +1,5 @@
+``kiel.protocol.sync_group``
+============================
+
+.. automodule:: kiel.protocol.sync_group
+    :members:

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -15,3 +15,4 @@ Protocol Definition
    modules/protocol.sync_group
    modules/protocol.leave_group
    modules/protocol.list_groups
+   modules/protocol.describe_groups

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -3,10 +3,11 @@ Protocol Definition
 
 .. toctree::
 
+   modules/protocol.metadata
    modules/protocol.fetch
    modules/protocol.produce
-   modules/protocol.metadata
-   modules/protocol.coordinator
    modules/protocol.offset
    modules/protocol.offset_commit
    modules/protocol.offset_fetch
+   modules/protocol.coordinator
+   modules/protocol.heartbeat

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -11,3 +11,4 @@ Protocol Definition
    modules/protocol.offset_fetch
    modules/protocol.coordinator
    modules/protocol.heartbeat
+   modules/protocol.join_group

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -6,7 +6,7 @@ Protocol Definition
    modules/protocol.fetch
    modules/protocol.produce
    modules/protocol.metadata
-   modules/protocol.consumer_metadata
+   modules/protocol.coordinator
    modules/protocol.offset
    modules/protocol.offset_commit
    modules/protocol.offset_fetch

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -13,3 +13,4 @@ Protocol Definition
    modules/protocol.heartbeat
    modules/protocol.join_group
    modules/protocol.sync_group
+   modules/protocol.leave_group

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -12,3 +12,4 @@ Protocol Definition
    modules/protocol.coordinator
    modules/protocol.heartbeat
    modules/protocol.join_group
+   modules/protocol.sync_group

--- a/docs/code/protocol_definition.rst
+++ b/docs/code/protocol_definition.rst
@@ -14,3 +14,4 @@ Protocol Definition
    modules/protocol.join_group
    modules/protocol.sync_group
    modules/protocol.leave_group
+   modules/protocol.list_groups

--- a/kiel/clients/grouped.py
+++ b/kiel/clients/grouped.py
@@ -6,9 +6,7 @@ import six
 from tornado import gen
 
 from kiel import constants, exc
-from kiel.protocol import (
-    consumer_metadata, offset_fetch, offset_commit, errors
-)
+from kiel.protocol import coordinator, offset_fetch, offset_commit, errors
 from kiel.zookeeper.allocator import PartitionAllocator
 
 from .consumer import BaseConsumer
@@ -106,9 +104,7 @@ class GroupedConsumer(BaseConsumer):
         contain coordinator metadata so each broker in the cluster is tried
         until one works.
         """
-        request = consumer_metadata.ConsumerMetadataRequest(
-            group=self.group_name
-        )
+        request = coordinator.GroupCoordinatorRequest(group=self.group_name)
         determined = False
         while not determined:
             broker_ids = list(self.cluster)
@@ -120,7 +116,7 @@ class GroupedConsumer(BaseConsumer):
                 if determined:
                     break
 
-    def handle_consumer_metadata_response(self, response):
+    def handle_group_coordinator_response(self, response):
         """
         Handler for consumer metadata api responses.
 

--- a/kiel/connection.py
+++ b/kiel/connection.py
@@ -7,7 +7,7 @@ from tornado import ioloop, iostream, gen, concurrent
 
 from kiel.exc import ConnectionError
 from kiel.protocol import (
-    metadata, consumer_metadata,
+    metadata, coordinator,
     produce, fetch,
     offset, offset_commit, offset_fetch
 )
@@ -27,7 +27,7 @@ response_classes = {
     "offset": offset.OffsetResponse,
     "offset_commit": offset_commit.OffsetCommitResponse,
     "offset_fetch": offset_fetch.OffsetFetchResponse,
-    "consumer_metadata": consumer_metadata.ConsumerMetadataResponse
+    "group_coordinator": coordinator.GroupCoordinatorResponse
 }
 
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -22,6 +22,7 @@ API_KEYS = {
     "group_coordinator": 10,
     "join_group": 11,
     "heartbeat": 12,
+    "leave_group": 13,
     "sync_group": 14,
 }
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -20,6 +20,7 @@ API_KEYS = {
     "offset_commit": 8,
     "offset_fetch": 9,
     "group_coordinator": 10,
+    "heartbeat": 12,
 }
 
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -20,6 +20,7 @@ API_KEYS = {
     "offset_commit": 8,
     "offset_fetch": 9,
     "group_coordinator": 10,
+    "join_group": 11,
     "heartbeat": 12,
 }
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -24,6 +24,7 @@ API_KEYS = {
     "heartbeat": 12,
     "leave_group": 13,
     "sync_group": 14,
+    "describe_groups": 15,
     "list_groups": 16,
 }
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -22,6 +22,7 @@ API_KEYS = {
     "group_coordinator": 10,
     "join_group": 11,
     "heartbeat": 12,
+    "sync_group": 14,
 }
 
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -24,6 +24,7 @@ API_KEYS = {
     "heartbeat": 12,
     "leave_group": 13,
     "sync_group": 14,
+    "list_groups": 16,
 }
 
 

--- a/kiel/constants.py
+++ b/kiel/constants.py
@@ -19,7 +19,7 @@ API_KEYS = {
     "metadata": 3,
     "offset_commit": 8,
     "offset_fetch": 9,
-    "consumer_metadata": 10,
+    "group_coordinator": 10,
 }
 
 

--- a/kiel/protocol/coordinator.py
+++ b/kiel/protocol/coordinator.py
@@ -3,39 +3,39 @@ from .response import Response
 from .primitives import String, Int16, Int32
 
 
-api_name = "consumer_metadata"
+api_name = "group_coordinator"
 
 __all__ = [
-    "ConsumerMetadataRequest",
-    "ConsumerMetadataResponse",
+    "GroupCoordinatorRequest",
+    "GroupCoordinatorResponse",
 ]
 
 
-class ConsumerMetadataRequest(Request):
+class GroupCoordinatorRequest(Request):
     """
     ::
 
-      ConsumerMetadataRequest =>
+      GroupCoordinatorRequest =>
         group_id => String
     """
-    api = "consumer_metadata"
+    api = "group_coordinator"
 
     parts = (
         ("group", String),
     )
 
 
-class ConsumerMetadataResponse(Response):
+class GroupCoordinatorResponse(Response):
     """
     ::
 
-      ConsumerMetadataResponse =>
+      GroupCoordinatorResponse =>
         error_code => Int16
         coordinator_id => Int32
         coordinator_host => String
         coordinator_port => Int32
     """
-    api = "consumer_metadata"
+    api = "group_coordinator"
 
     parts = (
         ("error_code", Int16),

--- a/kiel/protocol/describe_groups.py
+++ b/kiel/protocol/describe_groups.py
@@ -1,0 +1,117 @@
+from .part import Part
+from .request import Request
+from .response import Response
+from .primitives import Array, String, Int16, Int32, Bytes
+
+
+api_name = "describe_groups"
+
+
+__all__ = [
+    "DescribeGroupsRequest",
+    "DescribeGroupsResponse",
+    "GroupDescription",
+    "MemberDescription",
+    "Assignment",
+    "TopicAssignment",
+]
+
+
+class DescribeGroupsRequest(Request):
+    """
+    ::
+
+      DescribeGroupRequest =>
+        groups => [String]
+    """
+    api = "describe_groups"
+
+    parts = (
+        ("groups", Array.of(String)),
+    )
+
+
+class TopicAssignment(Part):
+    """
+    ::
+
+      TopicAssignment =>
+        name => String
+        partitions => [Int32]
+    """
+    parts = (
+        ("name", String),
+        ("partitions", Array.of(Int32)),
+    )
+
+
+class Assignment(Part):
+    """
+    ::
+
+      Assignment =>
+        version => Int16
+        topics => [TopicAssignment]
+        user_data => Bytes
+    """
+    parts = (
+        ("version", Int16),
+        ("topics", Array.of(TopicAssignment)),
+        ("user_data", Bytes),
+    )
+
+
+class MemberDescription(Part):
+    """
+    ::
+
+      MemberDescription =>
+        member_id => String
+        client_id => String
+        client_host => String
+        metadata => Bytes
+        assignment => Assignment
+    """
+    parts = (
+        ("member_id", String),
+        ("client_id", String),
+        ("client_host", String),
+        ("metadata", Bytes),
+        ("assignment", Assignment),
+    )
+
+
+class GroupDescription(Part):
+    """
+    ::
+
+      GroupDescription =>
+        error_code => Int16
+        group_id => String
+        state => String
+        protocol_type => String
+        protocol => String
+        members => [MemberDescription]
+    """
+    parts = (
+        ("error_code", Int16),
+        ("group_id", String),
+        ("state", String),
+        ("protocol_type", String),
+        ("protocol", String),
+        ("members", Array.of(MemberDescription)),
+    )
+
+
+class DescribeGroupsResponse(Response):
+    """
+    ::
+
+      DescribeGroupResponse =>
+        groups => [GroupDescription]
+    """
+    api = "describe_groups"
+
+    parts = (
+        ("groups", Array.of(GroupDescription)),
+    )

--- a/kiel/protocol/heartbeat.py
+++ b/kiel/protocol/heartbeat.py
@@ -1,0 +1,44 @@
+from .request import Request
+from .response import Response
+from .primitives import String, Int16, Int32
+
+
+api_name = "heartbeat"
+
+
+__all__ = [
+    "HeartbeatRequest",
+    "HeartbeatResponse"
+]
+
+
+class HeartbeatRequest(Request):
+    """
+    ::
+
+      HeartbeatRequest =>
+        group_id => String
+        generation_id = Int32
+        member_id => String
+    """
+    api = "heartbeat"
+
+    parts = (
+        "group_id", String,
+        "generation_id", Int32,
+        "member_id", String,
+    )
+
+
+class HeartbeatResponse(Response):
+    """
+    ::
+
+      HeartbeatResponse =>
+        error_code => Int16
+    """
+    api = "heartbeat"
+
+    parts = (
+        "error_code", Int16
+    )

--- a/kiel/protocol/join_group.py
+++ b/kiel/protocol/join_group.py
@@ -1,0 +1,93 @@
+from .part import Part
+from .request import Request
+from .response import Response
+from .primitives import Array, String, Bytes, Int16, Int32
+
+
+api_name = "join_group"
+
+
+__all__ = [
+    "JoinGroupRequest",
+    "JoinGroupResponse",
+    "GroupProtocol",
+    "Member",
+]
+
+
+class GroupProtocol(Part):
+    """
+    ::
+
+      GroupProtocol =>
+        name => String
+        version => Int16
+        subscription => Array.of(String)
+        user_data => Bytes
+    """
+    parts = (
+        ("name", String),
+        ("version", Int16),
+        ("subscription", Array.of(String)),
+        ("user_data", Bytes),
+    )
+
+
+class JoinGroupRequest(Request):
+    """
+    ::
+
+      JoinGroupRequest =>
+        group_id => String
+        session_timeout => Int32
+        member_id => String
+        protocol_type => String
+        group_protocols => [GroupProtocol]
+    """
+    api = "join_group"
+
+    parts = (
+        ("group_id", String),
+        ("session_timeout", Int32),
+        ("member_id", String),
+        ("protocol_type", String),
+        ("group_protocols", Array.of(GroupProtocol)),
+    )
+
+
+class Member(Part):
+    """
+    ::
+
+      Member =>
+        member_id => String
+        metadata => Bytes
+    """
+    parts = (
+        ("member_id", String),
+        ("metadata", Bytes),
+    )
+
+
+class JoinGroupResponse(Response):
+    """
+    ::
+
+      JoinGroupResponse =>
+        error_code => Int16
+        generation_id => Int32
+        protocol => String
+        leader_id => String
+        member_id => String
+        members => [Member]
+    """
+    api = "join_group"
+
+    parts = (
+        ("error_code", Int16),
+        ("generation_id", Int32),
+        ("protocol", String),
+        ("leader_id", String),
+        ("member_id", String),
+        ("members", Array.of(Member)),
+    )

--- a/kiel/protocol/leave_group.py
+++ b/kiel/protocol/leave_group.py
@@ -1,0 +1,42 @@
+from .request import Request
+from .response import Response
+from .primitives import String, Int16
+
+
+api_name = "leave_group"
+
+
+__all__ = [
+    "LeaveGroupRequest",
+    "LeaveGroupResponse",
+]
+
+
+class LeaveGroupRequest(Request):
+    """
+    ::
+
+      LeaveGroupRequest =>
+        group_id => String
+        member_id => String
+    """
+    api = "leave_group"
+
+    parts = (
+        ("group_id", String),
+        ("member_id", String),
+    )
+
+
+class LeaveGroupResponse(Response):
+    """
+    ::
+
+      LeaveGroupResponse =>
+        error_code => Int16
+    """
+    api = "leave_group"
+
+    parts = (
+        ("error_code", Int16),
+    )

--- a/kiel/protocol/list_groups.py
+++ b/kiel/protocol/list_groups.py
@@ -1,0 +1,55 @@
+from .part import Part
+from .request import Request
+from .response import Response
+from .primitives import Array, Int16, String
+
+
+api_name = "list_groups"
+
+
+__all__ = [
+    "ListGroupsRequest",
+    "ListGroupsResponse",
+    "Group",
+]
+
+
+class ListGroupsRequest(Request):
+    """
+    ::
+
+      ListGroupsRequest =>
+    """
+    api = "list_groups"
+
+    parts = ()
+
+
+class Group(Part):
+    """
+    ::
+
+      Group =>
+        group_id => String
+        protocol_type = > String
+    """
+    parts = (
+        ("group_id", String),
+        ("protocol_type", String),
+    )
+
+
+class ListGroupsResponse(Response):
+    """
+    ::
+
+      ListGroupsResponse =>
+        error_code => Int16
+        groups => [Group]
+    """
+    api = "list_groups"
+
+    parts = (
+        ("error_code", Int16),
+        ("groups", Array.of(Group)),
+    )

--- a/kiel/protocol/sync_group.py
+++ b/kiel/protocol/sync_group.py
@@ -1,0 +1,95 @@
+from .part import Part
+from .request import Request
+from .response import Response
+from .primitives import Array, String, Bytes, Int16, Int32
+
+
+api_name = "sync_group"
+
+
+__all__ = [
+    "SyncGroupRequest",
+    "SyncGroupResponse",
+    "MemberAssignment",
+    "TopicAssignment",
+]
+
+
+class TopicAssignment(Part):
+    """
+    ::
+
+      TopicAssignment =>
+        name => String
+        partitions => [Int32]
+    """
+    parts = (
+        ("name", String),
+        ("partitions", Array.of(Int32)),
+    )
+
+
+class Assignment(Part):
+    """
+    ::
+
+      Assignment =>
+        version => Int16
+        topics => [TopicAssignment]
+        user_data => Bytes
+    """
+    parts = (
+        ("version", Int16),
+        ("topics", Array.of(TopicAssignment)),
+        ("user_data", Bytes),
+    )
+
+
+class MemberAssignment(Part):
+    """
+    ::
+
+      MemberAssignment =>
+        member_id => String
+        assignment => Assignment
+    """
+    parts = (
+        ("member_id", String),
+        ("assignment", Assignment),
+    )
+
+
+class SyncGroupRequest(Request):
+    """
+    ::
+
+      SyncGroupRequest =>
+        group_id => String
+        generation_id => Int32
+        member_id => String
+        assignments => [MemberAssignment]
+    """
+    api = "sync_group"
+
+    parts = (
+        ("group_id", String),
+        ("generation_id", Int32),
+        ("member_id", String),
+        ("assignments", Array.of(MemberAssignment)),
+    )
+
+
+class SyncGroupResponse(Response):
+    """
+    ::
+
+      SyncGroupResponse =>
+        error_code => Int16
+        assignments => [MemberAssignment]
+    """
+    api = "sync_group"
+
+    parts = (
+        ("error_code", Int16),
+        ("assignments", Array.of(MemberAssignment)),
+    )

--- a/tests/clients/grouped_tests.py
+++ b/tests/clients/grouped_tests.py
@@ -5,7 +5,7 @@ from tornado import testing
 
 from kiel import exc
 from kiel.protocol import (
-    consumer_metadata, offset_fetch, offset_commit, fetch, messages, errors
+    coordinator, offset_fetch, offset_commit, fetch, messages, errors
 )
 from kiel.clients import grouped
 
@@ -21,9 +21,9 @@ class GroupedClientTests(cases.ClientTestCase):
 
         for broker_id in (1, 3, 8):
             self.set_responses(
-                broker_id=broker_id, api="consumer_metadata",
+                broker_id=broker_id, api="group_coordinator",
                 responses=[
-                    consumer_metadata.ConsumerMetadataResponse(
+                    coordinator.GroupCoordinatorResponse(
                         error_code=errors.no_error,
                         coordinator_id=3,
                         coordinator_host="kafka02",
@@ -124,12 +124,12 @@ class GroupedClientTests(cases.ClientTestCase):
 
         for broker_id in (1, 3, 8):
             self.set_responses(
-                broker_id=broker_id, api="consumer_metadata",
+                broker_id=broker_id, api="group_coordinator",
                 responses=[
-                    consumer_metadata.ConsumerMetadataResponse(
+                    coordinator.GroupCoordinatorResponse(
                         error_code=errors.request_timed_out,
                     ),
-                    consumer_metadata.ConsumerMetadataResponse(
+                    coordinator.GroupCoordinatorResponse(
                         error_code=errors.no_error,
                         coordinator_id=8,
                         coordinator_host="kafka02",
@@ -153,12 +153,12 @@ class GroupedClientTests(cases.ClientTestCase):
 
         for broker_id in (1, 3, 8):
             self.set_responses(
-                broker_id=broker_id, api="consumer_metadata",
+                broker_id=broker_id, api="group_coordinator",
                 responses=[
-                    consumer_metadata.ConsumerMetadataResponse(
+                    coordinator.GroupCoordinatorResponse(
                         error_code=errors.unknown
                     ),
-                    consumer_metadata.ConsumerMetadataResponse(
+                    coordinator.GroupCoordinatorResponse(
                         error_code=errors.no_error,
                         coordinator_id=8,
                         coordinator_host="kafka02",

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -15,6 +15,7 @@ import kiel.events
 import kiel.exc
 import kiel.iterables
 import kiel.protocol.coordinator
+import kiel.protocol.describe_groups
 import kiel.protocol.fetch
 import kiel.protocol.join_group
 import kiel.protocol.leave_group
@@ -50,6 +51,7 @@ modules_to_test = (
     kiel.exc,
     kiel.iterables,
     kiel.protocol.coordinator,
+    kiel.protocol.describe_groups,
     kiel.protocol.fetch,
     kiel.protocol.join_group,
     kiel.protocol.leave_group,

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -14,7 +14,7 @@ import kiel.constants
 import kiel.events
 import kiel.exc
 import kiel.iterables
-import kiel.protocol.consumer_metadata
+import kiel.protocol.coordinator
 import kiel.protocol.fetch
 import kiel.protocol.messages
 import kiel.protocol.metadata
@@ -45,7 +45,7 @@ modules_to_test = (
     kiel.events,
     kiel.exc,
     kiel.iterables,
-    kiel.protocol.consumer_metadata,
+    kiel.protocol.coordinator,
     kiel.protocol.fetch,
     kiel.protocol.messages,
     kiel.protocol.metadata,

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -17,6 +17,7 @@ import kiel.iterables
 import kiel.protocol.coordinator
 import kiel.protocol.fetch
 import kiel.protocol.join_group
+import kiel.protocol.leave_group
 import kiel.protocol.messages
 import kiel.protocol.metadata
 import kiel.protocol.offset
@@ -50,6 +51,7 @@ modules_to_test = (
     kiel.protocol.coordinator,
     kiel.protocol.fetch,
     kiel.protocol.join_group,
+    kiel.protocol.leave_group,
     kiel.protocol.messages,
     kiel.protocol.metadata,
     kiel.protocol.offset,

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -27,6 +27,7 @@ import kiel.protocol.primitives
 import kiel.protocol.produce
 import kiel.protocol.request
 import kiel.protocol.response
+import kiel.protocol.sync_group
 import kiel.zookeeper.allocator
 import kiel.zookeeper.party
 import kiel.zookeeper.shared_set
@@ -59,6 +60,7 @@ modules_to_test = (
     kiel.protocol.produce,
     kiel.protocol.request,
     kiel.protocol.response,
+    kiel.protocol.sync_group,
     kiel.zookeeper.allocator,
     kiel.zookeeper.party,
     kiel.zookeeper.shared_set,

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -18,6 +18,7 @@ import kiel.protocol.coordinator
 import kiel.protocol.fetch
 import kiel.protocol.join_group
 import kiel.protocol.leave_group
+import kiel.protocol.list_groups
 import kiel.protocol.messages
 import kiel.protocol.metadata
 import kiel.protocol.offset
@@ -52,6 +53,7 @@ modules_to_test = (
     kiel.protocol.fetch,
     kiel.protocol.join_group,
     kiel.protocol.leave_group,
+    kiel.protocol.list_groups,
     kiel.protocol.messages,
     kiel.protocol.metadata,
     kiel.protocol.offset,

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -16,6 +16,7 @@ import kiel.exc
 import kiel.iterables
 import kiel.protocol.coordinator
 import kiel.protocol.fetch
+import kiel.protocol.join_group
 import kiel.protocol.messages
 import kiel.protocol.metadata
 import kiel.protocol.offset
@@ -47,6 +48,7 @@ modules_to_test = (
     kiel.iterables,
     kiel.protocol.coordinator,
     kiel.protocol.fetch,
+    kiel.protocol.join_group,
     kiel.protocol.messages,
     kiel.protocol.metadata,
     kiel.protocol.offset,


### PR DESCRIPTION
* Renames "consumer metadata" to "group coordinator"

* Adds APIs for join/sync/leave group, plus listing/describing groups, plus heartbeat

Closes #3 