### PR TITLE
Use repr instead of strs for protocol classes.

### DIFF
--- a/kiel/protocol/messages.py
+++ b/kiel/protocol/messages.py
@@ -104,7 +104,7 @@ class MessageSet(object):
         """
         return self.messages == other.messages
 
-    def __str__(self):
+    def __repr__(self):
         return "[%s]" % ", ".join([str(m) for _, m in self.messages])
 
     @classmethod
@@ -214,5 +214,5 @@ class Message(Part):
         """
         return self.key == other.key and self.value == other.value
 
-    def __str__(self):
+    def __repr__(self):
         return "%s => %s" % (self.key, self.value)

--- a/kiel/protocol/part.py
+++ b/kiel/protocol/part.py
@@ -79,7 +79,7 @@ class Part(object):
         except AttributeError:
             return False
 
-    def __str__(self):
+    def __repr__(self):
 
         def subpart_string(part_info):
             part_name, part_class = part_info

--- a/kiel/protocol/primitives.py
+++ b/kiel/protocol/primitives.py
@@ -45,7 +45,7 @@ https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol
         """
         return self.value == other.value
 
-    def __str__(self):
+    def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, self.value)
 
 
@@ -133,8 +133,8 @@ class String(VariablePrimitive):
     """
     size_primitive = Int16
 
-    def __str__(self):
-        return '"' + self.value + '"'
+    def __repr__(self):
+        return '"%r"' % self.value
 
 
 class Bytes(VariablePrimitive):
@@ -212,5 +212,5 @@ class Array(Primitive):
 
         return values, offset
 
-    def __str__(self):
-        return "%s[%s]" % (self.item_class, ", ".join(map(str, self.value)))
+    def __repr__(self):
+        return "[%s]" % ", ".join(map(repr, self.value))

--- a/tests/protocol/messages_tests.py
+++ b/tests/protocol/messages_tests.py
@@ -1,0 +1,40 @@
+import json
+import unittest
+
+from kiel.protocol import messages
+
+
+class MessagesTests(unittest.TestCase):
+
+    def test_message_repr(self):
+        msg = messages.Message(
+            crc=0,
+            magic=0,
+            attributes=0,
+            key="foo",
+            value=json.dumps({"bar": "bazz"})
+        )
+
+        self.assertEqual(repr(msg), 'foo => {"bar": "bazz"}')
+
+    def test_messageset_repr(self):
+        msg1 = messages.Message(
+            crc=0,
+            magic=0,
+            attributes=0,
+            key="foo",
+            value=json.dumps({"bar": "bazz"})
+        )
+        msg2 = messages.Message(
+            crc=0,
+            magic=0,
+            attributes=0,
+            key="bar",
+            value=json.dumps({"bwee": "bwoo"})
+        )
+        msg_set = messages.MessageSet([(10, msg1), (11, msg2)])
+
+        self.assertEqual(
+            repr(msg_set),
+            '[foo => {"bar": "bazz"}, bar => {"bwee": "bwoo"}]'
+        )

--- a/tests/protocol/primitives_tests.py
+++ b/tests/protocol/primitives_tests.py
@@ -1,0 +1,16 @@
+import unittest
+
+from kiel.protocol import primitives
+
+
+class PrimitivesTests(unittest.TestCase):
+
+    def test_string_repr(self):
+        s = primitives.String(u"foobar")
+
+        self.assertEqual(repr(s), '"u\'foobar\'"')
+
+    def test_array_repr(self):
+        a = primitives.Array.of(primitives.Int32)([1, 3, 6, 9])
+
+        self.assertEqual(repr(a), "[1, 3, 6, 9]")


### PR DESCRIPTION
This way their internals are shown in error reporting rather than the
memory address of the instance.