### PR TITLE
Be smarter about String and Bytes serialization.

### DIFF
--- a/kiel/protocol/primitives.py
+++ b/kiel/protocol/primitives.py
@@ -1,5 +1,7 @@
 import struct
 
+import six
+
 
 class Primitive(object):
     """
@@ -72,7 +74,14 @@ class VariablePrimitive(Primitive):
         if self.value is None:
             return size_format, [-1]
 
-        value = bytes(str(self.value).encode("utf-8"))
+        value = self.value
+
+        if not isinstance(value, six.binary_type):
+            if not isinstance(value, six.string_types):
+                value = str(value)
+
+            value = value.encode("utf-8")
+
         size = len(value)
 
         format = "%s%ds" % (size_format, size)
@@ -93,7 +102,13 @@ class VariablePrimitive(Primitive):
 
         var_struct = struct.Struct("!%ds" % size)
 
-        value = var_struct.unpack_from(buff, offset)[0].decode("utf-8")
+        value = var_struct.unpack_from(buff, offset)[0]
+
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+
         offset += var_struct.size
 
         return value, offset

--- a/kiel/protocol/primitives.py
+++ b/kiel/protocol/primitives.py
@@ -134,7 +134,7 @@ class String(VariablePrimitive):
     size_primitive = Int16
 
     def __repr__(self):
-        return '"%r"' % self.value
+        return repr(self.value)
 
 
 class Bytes(VariablePrimitive):

--- a/tests/clients/producer_tests.py
+++ b/tests/clients/producer_tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from tests import cases
 
 from mock import patch
@@ -455,7 +457,7 @@ class ProducerTests(cases.ClientTestCase):
             ]
         )
 
-        msgs = ["foo", "bar"]
+        msgs = [u"foö", "bar"]
 
         p = producer.Producer(
             ["kafka01"], batch_size=2, compression=constants.GZIP
@@ -482,7 +484,7 @@ class ProducerTests(cases.ClientTestCase):
                                             magic=0,
                                             attributes=0,
                                             key=None,
-                                            value=p.serializer("foo"),
+                                            value=p.serializer(u"foö"),
                                         ),
                                         messages.Message(
                                             magic=0,

--- a/tests/protocol/primitives_tests.py
+++ b/tests/protocol/primitives_tests.py
@@ -8,7 +8,7 @@ class PrimitivesTests(unittest.TestCase):
     def test_string_repr(self):
         s = primitives.String(u"foobar")
 
-        self.assertEqual(repr(s), '%r' % repr(u"foobar"))
+        self.assertEqual(repr(s), repr(u"foobar"))
 
     def test_array_repr(self):
         a = primitives.Array.of(primitives.Int32)([1, 3, 6, 9])

--- a/tests/protocol/primitives_tests.py
+++ b/tests/protocol/primitives_tests.py
@@ -1,4 +1,8 @@
+import struct
 import unittest
+import zlib
+
+import six
 
 from kiel.protocol import primitives
 
@@ -14,3 +18,60 @@ class PrimitivesTests(unittest.TestCase):
         a = primitives.Array.of(primitives.Int32)([1, 3, 6, 9])
 
         self.assertEqual(repr(a), "[1, 3, 6, 9]")
+
+    def test_string_render_parse_is_stable(self):
+        s = primitives.String(u"foobar")
+
+        fmt, values = s.render()
+
+        raw = struct.pack("!" + fmt, *values)
+
+        value, _ = primitives.String.parse(raw, 0)
+
+        self.assertEqual(value, u"foobar")
+
+    def test_string_render_parse_handles_nonstrings(self):
+        s = primitives.String(123)
+
+        fmt, values = s.render()
+
+        raw = struct.pack("!" + fmt, *values)
+
+        value, _ = primitives.String.parse(raw, 0)
+
+        self.assertEqual(value, u"123")
+
+    def test_bytes_render_parse_is_stable(self):
+        b = primitives.Bytes(u"foobar")
+
+        fmt, values = b.render()
+
+        raw = struct.pack("!" + fmt, *values)
+
+        value, _ = primitives.Bytes.parse(raw, 0)
+
+        self.assertEqual(value, u"foobar")
+
+    def test_bytes_render_parse_handles_nonstrings(self):
+        s = primitives.Bytes(123)
+
+        fmt, values = s.render()
+
+        raw = struct.pack("!" + fmt, *values)
+
+        value, _ = primitives.Bytes.parse(raw, 0)
+
+        self.assertEqual(value, u"123")
+
+    def test_bytes_render_parse_handles_compressed_data(self):
+        data = zlib.compress(six.b("Best of times, blurst of times."))
+
+        s = primitives.Bytes(data)
+
+        fmt, values = s.render()
+
+        raw = struct.pack("!" + fmt, *values)
+
+        value, _ = primitives.Bytes.parse(raw, 0)
+
+        self.assertEqual(value, data)


### PR DESCRIPTION
We were running into errors sometimes when encoding/decoding values taht
had already been compressed.  This patch updates the VariablePrimitive
class to be smarter about doing both.

The type of the value instance is checked against bytes or strings or
unicode (using the six compatability library) to ensure that we always
end up rendering a sequence of bytes and those bytes are either
pre-supplied or stringified and utf-8 encoded.

When decoding we assume the value is encoded in utf-8 and move along if
it is not (as in the case of gzip'ed nested message sets)

Fixes #18