### PR TITLE
Run snappy compression tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ envs:
   - TOXENV=pypy
 before_install:
   - pip install codecov
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libsnappy-dev
+  - pip install python-snappy
 install: pip install tox
 script: tox
 after_success:

--- a/tests/compression/snappy_tests.py
+++ b/tests/compression/snappy_tests.py
@@ -25,7 +25,7 @@ class SnappyCompressionTests(unittest.TestCase):
         )
 
     def test_compression_is_stable(self):
-        data = json.dumps({"foo": "bar", "blee": "bloo", "dog": "cat"})
+        data = json.dumps({"foo": "bar", "dog": "cat"}).encode("utf-8")
 
         data = snappy.compress(data)
         data = snappy.decompress(data)
@@ -33,14 +33,18 @@ class SnappyCompressionTests(unittest.TestCase):
         data = snappy.decompress(data)
 
         self.assertEqual(
-            json.loads(data),
-            {"foo": "bar", "blee": "bloo", "dog": "cat"}
+            json.loads(data.decode("utf-8")),
+            {"foo": "bar", "dog": "cat"}
         )
 
     def test_compression_includes_magic_header(self):
-        data = json.dumps({"foo": "bar", "blee": "bloo", "dog": "cat"})
+        data = json.dumps(
+            {"foo": "bar", "blee": "bloo", "dog": "cat"}).encode("utf-8")
         data = snappy.compress(data)
 
         header = struct.unpack_from("!bccccccbii", data)
 
-        self.assertEqual(header, (-126, 'S', 'N', 'A', 'P', 'P', 'Y', 0, 1, 1))
+        self.assertEqual(
+            header,
+            (-126, b'S', b'N', b'A', b'P', b'P', b'Y', 0, 1, 1)
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 [testenv]
 usedevelop = True
 deps =
+     python-snappy
      nose
      coverage
      mock


### PR DESCRIPTION
Mostly a matter of getting the right packages installed and making sure
the tests are more diligent in encoding/decoding for python 3.