### PR TITLE
Fix iteration on Python 3.7

### DIFF
--- a/kiel/iterables.py
+++ b/kiel/iterables.py
@@ -1,3 +1,6 @@
+from __future__ import generator_stop
+
+
 def drain(iterable):
     """
     Helper method that empties an iterable as it is iterated over.
@@ -23,4 +26,4 @@ def drain(iterable):
         try:
             yield next_item(iterable)
         except (IndexError, KeyError):
-            raise StopIteration
+            return


### PR DESCRIPTION
PEP 479 changed handling of StopIteration inside generators. Since Python 3.7, _StopIteration_ errors raised from generators are implicitly converted to _RuntimeErrors_. The correct way of reporting the state when there is nothing more to yield is to return. See [PEP 479](
https://www.python.org/dev/peps/pep-0479)/.

The `import from __future__` ensures the same behavior on older versions of Python that don’t have this as default, making the tests fail without the actual fix. That includes Python 3.6.

The _test_iterables_ tests pass. Unfortunately I didn’t get some errors when running the whole test suite, even with _Python 3.6_. It looks like those are not introduced by this PR, since they happen on master too.

Fixes #34 .